### PR TITLE
Add SNTP, and dhcp_hostname support

### DIFF
--- a/src/config.erl-template
+++ b/src/config.erl-template
@@ -28,5 +28,10 @@ get() ->
         sta => [
             {ssid, "my_sta_ssid"},
             {psk, "my_sta_psk"}
+            %% uncomment below to use hostname
+           % ,{dhcp_hostname, "device_name.fqdn"}
+        ],
+        sntp => [
+            {host, "pool.ntp.org"}
         ]
     }.


### PR DESCRIPTION
Changes atomvm_shell.erl to use sntp server if it exists in config.erl, as well as use dhcp_hostname for the node, falling back to IP address if dhcp_hostname is not configured.

Adds pool.ntp.org timeserver to sntp config, and commented out dhcp_hostname example entry in src/config.erl-template.

Adds logger for configurable log levels for atomvm_shell.erl.